### PR TITLE
Suppress stderr output from run_command

### DIFF
--- a/lib/tty/screen.rb
+++ b/lib/tty/screen.rb
@@ -246,7 +246,7 @@ module TTY
     def run_command(*args)
       require 'tempfile'
       out = Tempfile.new('tty-screen')
-      result = system(*args, out: out.path)
+      result = system(*args, out: out.path, err: File::NULL)
       return if result.nil?
       out.rewind
       out.read


### PR DESCRIPTION
Tested to fix #6 within the affected Alpine Linux environment per https://gist.github.com/SpComb/96f770d67922f384a9146c5520378e2c#with-fix

```
kommando + ruby tty-screen
  does not output errors

Finished in 0.20655 seconds (files took 0.11936 seconds to load)
1 example, 0 failures
```