### PR TITLE
Avoid name resolution conflict whith TTY::File

### DIFF
--- a/lib/tty/screen.rb
+++ b/lib/tty/screen.rb
@@ -305,7 +305,7 @@ module TTY
     # @api private
     def command_exist?(command)
       exts = env.fetch("PATHEXT", "").split(::File::PATH_SEPARATOR)
-      env.fetch("PATH", "").split(File::PATH_SEPARATOR).any? do |dir|
+      env.fetch("PATH", "").split(::File::PATH_SEPARATOR).any? do |dir|
         file = ::File.join(dir, command)
         ::File.exist?(file) || exts.any? { |ext| ::File.exist?("#{file}#{ext}") }
       end


### PR DESCRIPTION
### Describe the change
Fixes bug with name resolution

### Why are we doing this?
When we use tty-screen alongside tty-file we have some problems with name resolution due to those gems share namespace `TTY`. similar to https://github.com/piotrmurach/tty-pager/pull/12

### Benefits
It will allow library to work with tty-file gem without unexpected errors

### Drawbacks
No Drawbacks

### Requirements
Put an X between brackets on each line if you have done the item:
- [x] Tests written & passing locally?
- [x] Code style checked?
- [x] Rebased with `master` branch?
- [x] Documentaion updated?
