### PR TITLE
Add rbs signatures

### DIFF
--- a/sig/tty/screen.rbs
+++ b/sig/tty/screen.rbs
@@ -1,0 +1,17 @@
+module TTY
+  module Screen
+    def self.cols: () -> Integer
+
+    def self.columns: () -> Integer
+
+    def self.height: () -> Integer
+
+    def self.lines: () -> Integer
+
+    def self.rows: () -> Integer
+
+    def self.size: () -> Integer
+
+    def self.width: () -> Integer
+  end
+end

--- a/tty-screen.gemspec
+++ b/tty-screen.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
     "rubygems_mfa_required" => "true",
     "source_code_uri" => "https://github.com/piotrmurach/tty-screen"
   }
-  spec.files = Dir["lib/**/*"]
+  spec.files = Dir["lib/**/*", "sig/**/*"]
   spec.extra_rdoc_files = ["README.md", "CHANGELOG.md", "LICENSE.txt"]
   spec.require_paths = ["lib"]
   spec.required_ruby_version = ">= 2.0.0"


### PR DESCRIPTION
### Describe the change

This adds RBS signatures for the Cursor module

### Why are we doing this?

To provide RBS signatures for consumers of the tty-cursor gem

### Benefits

Dependents don't have to maintain their own copies of the signatures for tty-cursor

### Drawbacks

Its another thing to maintain

### Requirements
<!--- Put an X between brackets on each line if you have done the item: -->
- [x] Tests written & passing locally?
- [ ] Code style checked?
- [x] Rebased with `master` branch?
- [ ] Documentation updated?
- [ ] Changelog updated?
